### PR TITLE
unused metrics (LastChange / LastChanged)

### DIFF
--- a/lib/check/interface.py
+++ b/lib/check/interface.py
@@ -215,6 +215,9 @@ class CheckInterface(Check):
             counts[name] += 1
             item['name'] = f'{name}_{idx}' if idx else name
 
+            # remove unused metric
+            item.pop('LastChange', None)
+
             items.append(item)
 
             try:

--- a/lib/check/ip_address.py
+++ b/lib/check/ip_address.py
@@ -26,6 +26,10 @@ class CheckIpAddress(Check):
         result = []
         missing = []
         for item in rows:
+
+            # remove unused metric
+            item.pop('LastChanged', None)
+
             try:
                 result.append(ip_mib_address(item['name'], item))
             except ParseKeyException as e:


### PR DESCRIPTION
## Description

Remove LastChange / LastChanged metric as this value is computed against the sysUptime. Unless we query this and calculate the actual timestamp, this value is not useful.


